### PR TITLE
Updated for FlatPress 1.3 / Smarty 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# flatpress_tag_plugin
-Tag Plugin for FlatPress v1.1
+# Tag Plugin for FlatPress 1.3
 
-developed originally by Pier Angelo Vendrame
-https://www.pierov.org/2011/08/01/plugin-tag-v25-flatpress/
+developed originally by [Piero Angelo Vendrame](https://www.pierov.org/2011/08/01/plugin-tag-v25-flatpress/)
 
-Modified to work with php7 flatpress
+modified to work with [FlatPress](https://github.com/flatpressblog/flatpress) 1.3 under PHP 7.1 to 8.1 and with Smarty 4.x.
 
-https://github.com/flatpressblog/flatpress
+Documentation on the FlatPress wiki: https://wiki.flatpress.org/res:plugins:tag

--- a/tag/inc/admin.php
+++ b/tag/inc/admin.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * This class removes the cache files for related entries.
  */
 class tag_relted_remover extends fs_filelister {
+
 	/**
 	 * Constructor: it calls the constructor of parent class
 	 * and it sets the directory to list.
@@ -14,19 +16,22 @@ class tag_relted_remover extends fs_filelister {
 	/**
 	 * This function checks the files and deletes them.
 	 *
- 	 * @param string $directory: The directory of the file to check
-	 * @param string $file: The file name
+	 * @param string $directory:
+	 *        	The directory of the file to check
+	 * @param string $file:
+	 *        	The file name
 	 * @return integer: See fs_filelister class
 	 */
 	function _checkFile($directory, $file) {
-		$f=$directory.$file;
-		if(fnmatch('tag-related*.tmp', $file)) {
+		$f = $directory . $file;
+		if (fnmatch('tag-related*.tmp', $file)) {
 			@unlink($f);
 		}
 		return 0;
 	}
 
 }
+
 /**
  * This class manages all actions in the Admin Panel
  * that are useful for the tag plugin.
@@ -34,11 +39,13 @@ class tag_relted_remover extends fs_filelister {
 class plugin_tag_admin {
 
 	# See plugin_tag
-	var $use_rewrite=false;
+	var $use_rewrite = false;
+
 	# The tag database, null for now
-	var $tagdb=null;
+	var $tagdb = null;
+
 	# The tag's entry utilites, null for now
-	var $entry=null;
+	var $entry = null;
 
 	/**
 	 * This is the content before that tags are stripped
@@ -46,34 +53,66 @@ class plugin_tag_admin {
 	 *
 	 * @var string
 	 */
-	var $simplecontent='';
+	var $simplecontent = '';
 
 	/**
 	 * plugin_tag_admin
 	 *
 	 * It manages hooks.
 	 *
-	 * @param object &$tagdb: the tag database object
-	 * @param object &$entry: the tag entry object
+	 * @param
+	 *        	object &$tagdb: the tag database object
+	 * @param
+	 *        	object &$entry: the tag entry object
 	 */
 	function __construct(&$tagdb, &$entry) {
-		$this->tagdb=&$tagdb;
-		$this->entry=&$entry;
-		add_filter('publish_post', array(&$this, 'entry_save'), 5, 2);
-		add_filter('delete_post', array(&$this, 'entry_delete'));
-		add_filter('wp_footer', array(&$this, 'purge_cache'));
+		$this->tagdb = &$tagdb;
+		$this->entry = &$entry;
+		add_filter('publish_post', array(
+			&$this,
+			'entry_save'
+		), 5, 2);
+		add_filter('delete_post', array(
+			&$this,
+			'entry_delete'
+		));
+		add_filter('wp_footer', array(
+			&$this,
+			'purge_cache'
+		));
 
-		if(!defined('MOD_ADMIN_PANEL') && version_compare(SYSTEM_VER, '0.1010', '>=')==1) {
+		if (!defined('MOD_ADMIN_PANEL') && version_compare(SYSTEM_VER, '0.1010', '>=') == 1) {
 			return;
 		}
 
-		add_filter('simple_edit_form', array(&$this, 'simple'));
-		add_filter('admin_entry_write_onsave', array(&$this, 'simpleadd'));
-		add_filter('admin_entry_write_onsavecontinue', array(&$this, 'simpleadd'));
-		add_filter('admin_entry_write_main', array(&$this, 'simpleremove'));
-		add_filter('admin_entry_write_onsubmit', array(&$this, 'simpleremove'));
-		add_action('wp_head', array(&$this, 'simplestyle'), 5);
-		add_action('init', array(&$this, 'simpleajax'));
+		add_filter('simple_edit_form', array(
+			&$this,
+			'simple'
+		));
+		add_filter('admin_entry_write_onsave', array(
+			&$this,
+			'simpleadd'
+		));
+		add_filter('admin_entry_write_onsavecontinue', array(
+			&$this,
+			'simpleadd'
+		));
+		add_filter('admin_entry_write_main', array(
+			&$this,
+			'simpleremove'
+		));
+		add_filter('admin_entry_write_onsubmit', array(
+			&$this,
+			'simpleremove'
+		));
+		add_action('wp_head', array(
+			&$this,
+			'simplestyle'
+		), 5);
+		add_action('init', array(
+			&$this,
+			'simpleajax'
+		));
 	}
 
 	/**
@@ -82,78 +121,80 @@ class plugin_tag_admin {
 	 * Function called on entry_save hook.
 	 * It updates the tags database
 	 *
-	 * @param string $id: the entry id
-	 * @param array $array: the entry array
+	 * @param string $id:
+	 *        	the entry id
+	 * @param array $array:
+	 *        	the entry array
 	 * @returns boolean true (always)
 	 */
 	function entry_save($id, $array) {
-		$toremove=array();
+		$toremove = array();
 
 		# Get the tags of the entry
-		$this->entry->tag_list($array['content']);
-		$tags=$this->entry->tags;
+		$this->entry->tag_list($array ['content']);
+		$tags = $this->entry->tags;
 
 		# If the entry already exists...
-		if(entry_exists($id)) {
+		if (entry_exists($id)) {
 			# Get old tags
-			$entry=entry_parse($id);
-			$this->entry->tag_list($entry['content']);
-			$old_tags=$this->entry->tags;
+			$entry = entry_parse($id);
+			$this->entry->tag_list($entry ['content']);
+			$old_tags = $this->entry->tags;
 			# Get tags to remove
-			$toremove=array_values(array_diff($old_tags, $tags));
+			$toremove = array_values(array_diff($old_tags, $tags));
 			# Don't do anything with tags that there were already
-			$tags=array_values(array_diff($tags, $old_tags));
+			$tags = array_values(array_diff($tags, $old_tags));
 		}
 
 		# Add tags
-		for($i=0; $i<count($tags); $i++) {
-			$file=$this->tagdb->tagfile($tags[$i]);
+		for($i = 0; $i < count($tags); $i++) {
+			$file = $this->tagdb->tagfile($tags [$i]);
 			$this->tagdb->open_file($file);
-			$this->tagdb->files[$file][$tags[$i]][]=$id;
+			$this->tagdb->files [$file] [$tags [$i]] [] = $id;
 		}
 
 		# Remove old tags
-		for($i=0; $i<count($toremove); $i++) {
-			$file=$this->tagdb->tagfile($toremove[$i]);
-			$f=$this->tagdb->open_file($file);
+		for($i = 0; $i < count($toremove); $i++) {
+			$file = $this->tagdb->tagfile($toremove [$i]);
+			$f = $this->tagdb->open_file($file);
 
-			if(!isset($f[$toremove[$i]])) {
+			if (!isset($f [$toremove [$i]])) {
 				continue;
 			}
 
-			$k=array_search($id, $f[$toremove[$i]]);
-			if(isset($f[$toremove[$i]][$k])) {
-				unset($f[$toremove[$i]][$k]);
+			$k = array_search($id, $f [$toremove [$i]]);
+			if (isset($f [$toremove [$i]] [$k])) {
+				unset($f [$toremove [$i]] [$k]);
 			}
 
 			# If tag hasn't entries, remove it
-			$f[$toremove[$i]]=array_values($f[$toremove[$i]]);
-			if(!count($f[$toremove[$i]])) {
-				unset($f[$toremove[$i]]);
+			$f [$toremove [$i]] = array_values($f [$toremove [$i]]);
+			if (!count($f [$toremove [$i]])) {
+				unset($f [$toremove [$i]]);
 			}
 
-			$this->tagdb->files[$file]=$f;
+			$this->tagdb->files [$file] = $f;
 		}
 
-		## CRITICAL!! It saves the work
+		# # CRITICAL!! It saves the work
 		$this->tagdb->save_all();
 
 		# If we use rewrite, we have to rebuild cache.
-		if($this->use_rewrite) {
+		if ($this->use_rewrite) {
 			$this->tagdb->rewriteCache(true);
 		}
 
 		# We don't make immediately the cache of widgets:
 		# maybe the tag widget is not used anymore.
-		if(file_exists(CACHE_DIR.'tag-widget.tmp')) {
-			@unlink(CACHE_DIR.'tag-widget.tmp');
+		if (file_exists(CACHE_DIR . 'tag-widget.tmp')) {
+			@unlink(CACHE_DIR . 'tag-widget.tmp');
 		}
-		$remover=new tag_relted_remover();
+		$remover = new tag_relted_remover();
 		$remover->getList();
 
 		# Clean the cache of ajax
-		if(file_exists(CACHE_DIR.'tag-ajax.tmp')) {
-			@unlink(CACHE_DIR.'tag-ajax.tmp');
+		if (file_exists(CACHE_DIR . 'tag-ajax.tmp')) {
+			@unlink(CACHE_DIR . 'tag-ajax.tmp');
 		}
 
 		return true;
@@ -165,47 +206,48 @@ class plugin_tag_admin {
 	 * This function is called by hook entry_delete.
 	 * It updates the tag database
 	 *
-	 * @param string $id: The id of the entry that is being deleted.
+	 * @param string $id:
+	 *        	The id of the entry that is being deleted.
 	 * @returns boolean true (always)
 	 */
 	function entry_delete($id) {
 		# D'oh! We need to find in the database because entry doesn't exist anymore!
 		# So ugly function, a linear parse of all tags! Oh my...
-		$lister=new tag_lister();
-		$list=$lister->_list;
-		if(!count($list)) {
+		$lister = new tag_lister();
+		$list = $lister->_list;
+		if (!count($list)) {
 			# There is no tag, let's stop here
 			return true;
 		}
 
 		# Very similar to entry_save
-		foreach($list as $file) {
-			$f=$this->tagdb->open_file($file);
-			if(!count($f)) {
+		foreach ($list as $file) {
+			$f = $this->tagdb->open_file($file);
+			if (!count($f)) {
 				continue;
 			}
-			foreach($f as $tag=>$entries) {
-				$k=array_keys($entries, $id);
-				if(@isset($entries[$k[0]])) {
-					unset($this->tagdb->files[$file][$tag][$k[0]]);
+			foreach ($f as $tag => $entries) {
+				$k = array_keys($entries, $id);
+				if (@isset($entries [$k [0]])) {
+					unset($this->tagdb->files [$file] [$tag] [$k [0]]);
 				}
-				if(count($this->tagdb->files[$file][$tag])==0) {
-					unset($this->tagdb->files[$file][$tag]);
+				if (count($this->tagdb->files [$file] [$tag]) == 0) {
+					unset($this->tagdb->files [$file] [$tag]);
 				}
 			}
 		}
 
 		$this->tagdb->save_all();
 
-		if($this->use_rewrite) {
+		if ($this->use_rewrite) {
 			$this->tagdb->rewriteCache(true);
 		}
 
 		# See at lines 127-128
-		if(file_exists(CACHE_DIR.'tag-widget.tmp')) {
-			@unlink(CACHE_DIR.'tag-widget.tmp');
+		if (file_exists(CACHE_DIR . 'tag-widget.tmp')) {
+			@unlink(CACHE_DIR . 'tag-widget.tmp');
 		}
-		$remover=new tag_relted_remover();
+		$remover = new tag_relted_remover();
 		$remover->getList();
 
 		return true;
@@ -219,18 +261,18 @@ class plugin_tag_admin {
 	 * the cache of templates.
 	 */
 	function purge_cache() {
-		if(PLUGIN_TAG_NOCACHE) {
+		if (PLUGIN_TAG_NOCACHE) {
 			return false;
 		}
 
-		if(empty($_GET['do'])) {
+		if (empty($_GET ['do'])) {
 			return false;
 		}
 
 		# Just if we are in mantain panel
-		if(ADMIN_PANEL=='maintain' && $_GET['do']=='purgetplcache') {
+		if (ADMIN_PANEL == 'maintain' && $_GET ['do'] == 'purgetplcache') {
 			fs_delete_recursive(PLUGIN_TAG_DIR);
-			if(!is_dir(PLUGIN_TAG_DIR)) {
+			if (!is_dir(PLUGIN_TAG_DIR)) {
 				@fs_mkdir(PLUGIN_TAG_DIR);
 			}
 			# Rebuild cache
@@ -239,7 +281,6 @@ class plugin_tag_admin {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -247,26 +288,28 @@ class plugin_tag_admin {
 	 */
 	function simple() {
 		global $lang, $smarty;
-		if(!isset($lang['admin']['plugin']['tag'])) {
-			$lang=lang_load('plugin:tag');
+		if (!isset($lang ['admin'] ['plugin'] ['tag'])) {
+			$lang = lang_load('plugin:tag');
 		}
 
 		// Get the simple tags
-		if(!empty($this->simplebody)) {
-			$entry=array('content'=>$this->simplebody);
+		if (!empty($this->simplebody)) {
+			$entry = array(
+				'content' => $this->simplebody
+			);
 		} else {
-			$entry=$smarty->get_template_vars('post');
+			$entry = $smarty->getTemplateVars('post');
 		}
-		$this->entry->tag_list($entry['content']);
-		$tags=$this->entry->tags;
-		if(!empty($_POST['taginput'])) {
-			$tags=array_merge((array)$tags, explode(',', $_POST['taginput']));
+		$this->entry->tag_list($entry ['content']);
+		$tags = $this->entry->tags;
+		if (!empty($_POST ['taginput'])) {
+			$tags = array_merge((array) $tags, explode(',', $_POST ['taginput']));
 		}
-		$tags=array_map('trim', $tags);
-		$tags=array_unique($tags);
-		$tagsimple=implode(', ', $tags);
+		$tags = array_map('trim', $tags);
+		$tags = array_unique($tags);
+		$tagsimple = implode(', ', $tags);
 
-		$smarty->assign('taglang', $lang['admin']['plugin']['tag']);
+		$smarty->assign('taglang', $lang ['admin'] ['plugin'] ['tag']);
 		$smarty->assign('tags_simple', $tagsimple);
 		$smarty->display('plugin:tag/tagsimple');
 
@@ -277,10 +320,10 @@ class plugin_tag_admin {
 	 * This function prints the stylesheet of the template
 	 */
 	function simplestyle() {
-		if (ADMIN_PANEL=='entry') {
-			if (ADMIN_PANEL_ACTION=='write') {
-				$h=plugin_geturl('tag').'res/admin.css';
-				echo '<link rel="stylesheet" type="text/css" href="'.$h."\" />\n";
+		if (ADMIN_PANEL == 'entry') {
+			if (ADMIN_PANEL_ACTION == 'write') {
+				$h = plugin_geturl('tag') . 'res/admin.css';
+				echo '<link rel="stylesheet" type="text/css" href="' . $h . "\" />\n";
 			}
 		}
 	}
@@ -289,50 +332,51 @@ class plugin_tag_admin {
 	 * This function reads the tags to the textarea.
 	 */
 	function simpleadd() {
-		if(empty($_POST['taginput'])) {
+		if (empty($_POST ['taginput'])) {
 			return;
 		}
 
-		$tags=$_POST['taginput'];
-		if(substr($tags, -1)==',') {
-			$tags=substr($tags, 0, -1);
+		$tags = $_POST ['taginput'];
+		if (substr($tags, -1) == ',') {
+			$tags = substr($tags, 0, -1);
 		}
-		$tags=explode(',', $tags);
-		$tags=array_filter($tags);
+		$tags = explode(',', $tags);
+		$tags = array_filter($tags);
 
-		$cont=$_POST['content'];
-		$cont=$this->entry->tag_list($cont);
-		$tags=array_merge($tags, $this->entry->tags);
-		$tags=array_map('trim', $tags);
-		$tags=array_unique($tags);
+		$cont = $_POST ['content'];
+		$cont = $this->entry->tag_list($cont);
+		$tags = array_merge($tags, $this->entry->tags);
+		$tags = array_map('trim', $tags);
+		$tags = array_unique($tags);
 
-		$tags=implode(', ', $tags);
-		$cont=trim($cont);
-		$cont.="\n[tag]{$tags}[/tag]";
+		$tags = implode(', ', $tags);
+		$cont = trim($cont);
+		$cont .= "\n[tag]{$tags}[/tag]";
 
-		$_POST['content']=$cont;
+		$_POST ['content'] = $cont;
 	}
 
 	/**
 	 * This function removes [tag] from the content.
 	 *
-	 * @param string $content: The entry content
+	 * @param string $content:
+	 *        	The entry content
 	 * @return string: $content modified
 	 */
 	function simpleremove() {
 		global $smarty;
 
-		$post=$smarty->get_template_vars('post');
-		$content=@$post['content'];
+		$post = $smarty->getTemplateVars('post');
+		$content = @$post ['content'];
 
-		if(empty($content)) {
+		if (empty($content)) {
 			return;
 		}
 
-		$this->simplebody=$content;
-		$content=preg_replace('/\[tag\](.*)\[\/tag\]/im', '', $content);
+		$this->simplebody = $content;
+		$content = preg_replace('/\[tag\](.*)\[\/tag\]/im', '', $content);
 
-		$post['content']=$content;
+		$post ['content'] = $content;
 		$smarty->assign('post', $post);
 	}
 
@@ -340,47 +384,49 @@ class plugin_tag_admin {
 	 * This function handles the ajax function of the plugin.
 	 */
 	function simpleajax() {
-		if(@$_GET['ajaxtag']!='list') {
+		if (@$_GET ['ajaxtag'] != 'list') {
 			return;
 		}
 
-		if(empty($_GET['tag'])) {
-			die;
+		if (empty($_GET ['tag'])) {
+			die();
 		}
 
 		// Make the list
-		if(file_exists($f=CACHE_DIR.'tag-ajax.tmp') && (filemtime($f)-time())<3600) {
+		if (file_exists($f = CACHE_DIR . 'tag-ajax.tmp') && (filemtime($f) - time()) < 3600) {
 			include $f;
 		} else {
-			$lister=new tag_lister();
-			$tags=array_keys($lister->makeTagList());
+			$lister = new tag_lister();
+			$tags = array_keys($lister->makeTagList());
 			natcasesort($tags);
-			system_save($f, array('tags'=>$tags));
+			system_save($f, array(
+				'tags' => $tags
+			));
 		}
 
-		$suggs=array();
-		$tag=strtolower($_GET['tag']);
-		$tagl=array_map('strtolower', $tags);
-		foreach($tagl as $key=>$val) {
-			if($tag==substr($val, 0, strlen($tag))) {
-				$tmp=wp_specialchars($tags[$key]);
-				$suggs[]='<b>'.substr($tmp, 0, strlen($tag)).'</b>'.substr($tmp, strlen($tag));
+		$suggs = array();
+		$tag = strtolower($_GET ['tag']);
+		$tagl = array_map('strtolower', $tags);
+		foreach ($tagl as $key => $val) {
+			if ($tag == substr($val, 0, strlen($tag))) {
+				$tmp = wp_specialchars($tags [$key]);
+				$suggs [] = '<b>' . substr($tmp, 0, strlen($tag)) . '</b>' . substr($tmp, strlen($tag));
 			}
 		}
 
-		if(count($suggs)>10) {
+		if (count($suggs) > 10) {
 			// Only ten suggestions
-			$suggs=array_slice($suggs, 0, 10);
+			$suggs = array_slice($suggs, 0, 10);
 		}
 
-		$sugghtml='<ul>';
-		foreach($suggs as $sugg) {
-			$sugghtml.="<li>{$sugg}</li>\n";
+		$sugghtml = '<ul>';
+		foreach ($suggs as $sugg) {
+			$sugghtml .= "<li>{$sugg}</li>\n";
 		}
-		$sugghtml.='</ul>';
+		$sugghtml .= '</ul>';
 
-		if(count($suggs)==0) {
-			$sugghtml='';
+		if (count($suggs) == 0) {
+			$sugghtml = '';
 		}
 		die($sugghtml);
 	}

--- a/tag/inc/entry.php
+++ b/tag/inc/entry.php
@@ -1,61 +1,75 @@
 <?php
+
 /**
  * plugin_tag_entry
  *
  * The entry utilities of the plugin tag.
  */
 class plugin_tag_entry {
+
 	/**
 	 * Where tags are saved.
 	 * This variable must always exists.
 	 *
 	 * @var array
 	 */
-	var $tags=array();
+	var $tags = array();
 
 	/**
 	 * This is the cache of entry by id.
 	 *
 	 * @var array
 	 */
-	var $_cache=array();
+	var $_cache = array();
 
 	/**
 	 * Merge the tags or delete the current tags?
 	 *
 	 * @var boolean
 	 */
-	var $merge=false;
+	var $merge = false;
 
 	/**
-	 * The tagdb instance. Used to count entries
+	 * The tagdb instance.
+	 * Used to count entries
 	 * that have a certain tag.
 	 *
 	 * @var object
 	 */
-	var $tagdb=null;
+	var $tagdb = null;
 
 	/**
-	 * The constructor. It doesn't do so much.
+	 * The constructor.
+	 * It doesn't do so much.
 	 *
-	 * @param object $tagdb: The tagdb instance
+	 * @param object $tagdb:
+	 *        	The tagdb instance
 	 */
 	function __construct(&$tagdb) {
 		global $smarty;
 
 		// To list tags in the template
-		$smarty->assign_by_ref('tags', $this->tags);
-		$smarty->register_modifier('tagplugin_list', array(&$this, 'smarty_modifier'));
+		$smarty->assignByRef('tags', $this->tags);
+		$smarty->registerPlugin('modifier', 'tagplugin_list', array(
+			&$this,
+			'smarty_modifier'
+		));
 
 		// Save the tagdb instance
-		$this->tagdb=&$tagdb;
+		$this->tagdb = &$tagdb;
 
 		// Do the tag list
-		add_filter('the_content', array(&$this, 'tag_list'), 0);
+		add_filter('the_content', array(
+			&$this,
+			'tag_list'
+		), 0);
 
 		// The automatic bottom list
-		if(PLUGIN_TAG_BL) {
-			add_filter('the_content', array(&$this, 'tag_bottomlist'), 50);
+		if (PLUGIN_TAG_BL) {
+			add_filter('the_content', array(
+				&$this,
+				'tag_bottomlist'
+			), 50);
 		}
 	}
 
@@ -66,31 +80,36 @@ class plugin_tag_entry {
 	 * This function is used as callback from the BBCode class
 	 * to save tags from an entry.
 	 *
-	 * @param string $action: the action (see the BBCode class manual)
-	 * @param array $attributes: ??? (see the BBCode class manual)
-	 * @param string $content: what is content of [tag][/tag]
-	 * @param array $params: ??? (see the BBCode class manual)
-	 * @param ??? $node_obhect: ???  (see the BBCode class manual)
+	 * @param string $action:
+	 *        	the action (see the BBCode class manual)
+	 * @param array $attributes:
+	 *        	??? (see the BBCode class manual)
+	 * @param string $content:
+	 *        	what is content of [tag][/tag]
+	 * @param array $params:
+	 *        	??? (see the BBCode class manual)
+	 * @param ??? $node_obhect:
+	 *        	??? (see the BBCode class manual)
 	 * @returns void string
 	 */
 	function do_bbcode($action, $attributes, $content, $params, $node_object) {
-		if ($action=='validate') {
+		if ($action == 'validate') {
 			return true;
 		}
 
-		if(empty($content)) {
+		if (empty($content)) {
 			return '';
 		}
 
-		$t=explode(',', $content);
-		$t=array_map('trim', $t);
+		$t = explode(',', $content);
+		$t = array_map('trim', $t);
 
-		if($this->merge) {
-			$t=array_merge((array)$this->tags, $t);
+		if ($this->merge) {
+			$t = array_merge((array) $this->tags, $t);
 		}
 
-		$t=array_unique($t);
-		$this->tags=$t;
+		$t = array_unique($t);
+		$this->tags = $t;
 
 		return '';
 	}
@@ -104,20 +123,19 @@ class plugin_tag_entry {
 	 * returns object: the StringParser_BBCode instance
 	 */
 	function load_bbcode() {
-		$tag_bbcode=new StringParser_BBCode();
-		$tag_bbcode->addCode(
-			'tag',
-			'callback_replace',
-			array(&$this, 'do_bbcode'),
-			array(
-				'usecontent_param' => array('default')
-			),
-			'inline',
-			array(
-				'listitem', 'block', 'inline'
-			),
-			array()
-		);
+		$tag_bbcode = new StringParser_BBCode();
+		$tag_bbcode->addCode('tag', 'callback_replace', array(
+			&$this,
+			'do_bbcode'
+		), array(
+			'usecontent_param' => array(
+				'default'
+			)
+		), 'inline', array(
+			'listitem',
+			'block',
+			'inline'
+		), array());
 		$tag_bbcode->setCodeFlag('tag', 'closetag', BBCODE_CLOSETAG_MUSTEXIST);
 		return $tag_bbcode;
 	}
@@ -127,21 +145,22 @@ class plugin_tag_entry {
 	 *
 	 * It makes the list of tag from an entry.
 	 *
-	 * @param string $content: the content of the entry
+	 * @param string $content:
+	 *        	the content of the entry
 	 * @returns string: $content without tags
 	 */
 	function tag_list($content) {
 		# Clean old tags
-		$this->tags=array();
+		$this->tags = array();
 		# Enable tag merge
-		$this->merge=true;
+		$this->merge = true;
 		# Load the tag parser and parse them
-		$tag_bbcode=$this->load_bbcode();
-		if(false!==$post=$tag_bbcode->parse($content)) {
-			$content=$post;
+		$tag_bbcode = $this->load_bbcode();
+		if (false !== $post = $tag_bbcode->parse($content)) {
+			$content = $post;
 		}
 		# Disable tag merge
-		$this->merge=false;
+		$this->merge = false;
 		# Return the modified content
 		return $content;
 	}
@@ -152,39 +171,41 @@ class plugin_tag_entry {
 	 * This is the modifier that is used to auto-list tag (with link) in
 	 * the templates.
 	 *
-	 * @param array $array: the tags of the post ({$tags} in smarty)
-	 * @param string $glue: how to join tags [default: , ]
-	 * @param string $default: if there aren't tags...
+	 * @param array $array:
+	 *        	the tags of the post ({$tags} in smarty)
+	 * @param string $glue:
+	 *        	how to join tags [default: , ]
+	 * @param string $default:
+	 *        	if there aren't tags...
 	 * @returns: The tag list or $default
 	 */
-	function smarty_modifier($array, $glue=', ', $default='No Tags') {
+	function smarty_modifier($array, $glue = ', ', $default = 'No Tags') {
 		// If there aren't tags, let's return $default
-		if(!is_array($array) || !count($array)) {
+		if (!is_array($array) || !count($array)) {
 			return $default;
 		}
 
 		// Load lang
 		global $lang;
-		if(!isset($lang['plugin']['tag'])) {
+		if (!isset($lang ['plugin'] ['tag'])) {
 			load_lang('plugin:tag');
 		}
-		$plang=$lang['plugin']['tag'];
+		$plang = $lang ['plugin'] ['tag'];
 
-
-		$links=array();
+		$links = array();
 		// Ok, foreach already checked
-		foreach($array as $v) {
+		foreach ($array as $v) {
 			// To be compatible with Flatpress System, we use the filter
-			$link=apply_filters('tag_link', $v);
+			$link = apply_filters('tag_link', $v);
 
 			// For LAttilaD: show number of entries
-			$entries=$this->tagdb->taggedEntries($v);
-			$count=count($entries);
-			$titleadd=$count==1 ? $plang['oneentry'] : $count.$plang['entries'];
-			$titleadd=" ({$titleadd})";
+			$entries = $this->tagdb->taggedEntries($v);
+			$count = count($entries);
+			$titleadd = $count == 1 ? $plang ['oneentry'] : $count . $plang ['entries'];
+			$titleadd = " ({$titleadd})";
 
-			$v=wp_specialchars($v, true);
-			$links[]="\n".'<a href="'.$link.'" title="'.$v.$titleadd.'">'.$v.'</a>';
+			$v = wp_specialchars($v, true);
+			$links [] = "\n" . '<a href="' . $link . '" title="' . $v . $titleadd . '">' . $v . '</a>';
 		}
 		return implode($glue, $links);
 	}
@@ -194,24 +215,25 @@ class plugin_tag_entry {
 	 *
 	 * This function adds the tag list at the entry bottom.
 	 *
-	 * @param $content: The original content of the entry
+	 * @param $content: The
+	 *        	original content of the entry
 	 * @return string: The modified $content
 	 */
 	function tag_bottomlist($content) {
 		# If there aren't tags
-		if(empty($this->tags)) {
+		if (empty($this->tags)) {
 			return $content;
 		}
 
 		# Load lang
 		global $lang;
-		if(!isset($lang['plugin']['tag'])) {
+		if (!isset($lang ['plugin'] ['tag'])) {
 			load_lang('plugin:tag');
 		}
 
-		$taglist=$lang['plugin']['tag']['tag_s'];
-		$taglist.=$this->smarty_modifier($this->tags);
-		$content.="\n<div class=\"plugin_tag_list\">{$taglist}</div>\n";
+		$taglist = $lang ['plugin'] ['tag'] ['tag_s'];
+		$taglist .= $this->smarty_modifier($this->tags);
+		$content .= "\n<div class=\"plugin_tag_list\">{$taglist}</div>\n";
 		return $content;
 	}
 
@@ -219,25 +241,27 @@ class plugin_tag_entry {
 	 * This function is similar to tag_list but it loads the entry
 	 * by his ID and then it returns the tags.
 	 *
-	 * @param string $id: The entry ID
-	 * @param boolean $force: Must I ignore cache?
+	 * @param string $id:
+	 *        	The entry ID
+	 * @param boolean $force:
+	 *        	Must I ignore cache?
 	 * @return array: The tags
 	 */
-	function entryTags($id, $force=false) {
-		if(!$force && isset($this->_cache[$id])) {
-			return $this->_cache[$id];
+	function entryTags($id, $force = false) {
+		if (!$force && isset($this->_cache [$id])) {
+			return $this->_cache [$id];
 		}
 
-		$entry=entry_parse($id);
-		if(!isset($entry['content'])) {
+		$entry = entry_parse($id);
+		if (!isset($entry ['content'])) {
 			return array();
 		}
 
-		$before=$this->tags;
-		$this->tag_list($entry['content']);
-		$this->_cache[$id]=$this->tags;
-		$tags=$this->tags;
-		$this->tags=$before;
+		$before = $this->tags;
+		$this->tag_list($entry ['content']);
+		$this->_cache [$id] = $this->tags;
+		$tags = $this->tags;
+		$this->tags = $before;
 
 		return $tags;
 	}

--- a/tag/plugin.tag.php
+++ b/tag/plugin.tag.php
@@ -1,19 +1,19 @@
 <?php
 /*
-Plugin Name: Tag
-Version: 2.5.4 - php7
-Plugin URI: https://github.com/ebal/flatpress_tag_plugin/
-Description: Allows using tags in flatpress. This plugin requires BBCode
-Author: Pier Angelo Vendrame
-Maintainer: Evaggelos Balaskas
-*/
+ * Plugin Name: Tag
+ * Version: 2.6
+ * Plugin URI: https://github.com/ebal/flatpress_tag_plugin/
+ * Description: Allows using tags in flatpress. This plugin requires BBCode
+ * Author: Piero Angelo Vendrame, maintained by Evaggelos Balaskas
+ * Author URI: https://github.com/ebal/
+ */
 
 # Show tag list in the bottom of every entry? Values: true (yes) OR false (no)
 define('PLUGIN_TAG_BL', true);
 # Max tags shown in the cloud
 define('PLUGIN_TAG_MAXC', 50);
 # Where save tags
-define('PLUGIN_TAG_DIR', FP_CONTENT.'plugin_tag/');
+define('PLUGIN_TAG_DIR', FP_CONTENT . 'plugin_tag/');
 # Minimum size of tags in the cloud?
 define('PLUGIN_TAG_WMIN', 10);
 # Maximum size of tags in the cloud?
@@ -28,16 +28,20 @@ define('PLUGIN_TAG_ALLOW_NOT', false);
 define('PLUGIN_TAG_NOCACHE', false);
 
 function plugin_tag_setup() {
-	return function_exists('plugin_bbcode_init')? 1:-1;
+	return function_exists('plugin_bbcode_init') ? 1 : -1;
 }
 
 class plugin_tag {
+
 	# Is PrettyURLs or RewriteURLs enabled?
-	var $rewrite_link=false;
+	var $rewrite_link = false;
+
 	# Tagdb, null for now
-	var $tagdb_class=null;
+	var $tagdb_class = null;
+
 	# Entry_tag, null for now
-	var $entry_class=null;
+	var $entry_class = null;
+
 	/**
 	 * plugin_tag
 	 *
@@ -48,50 +52,62 @@ class plugin_tag {
 		global $smarty;
 
 		# Include basic files
-		$tag_inc=dirname(__FILE__).'/inc/';
-		include_once $tag_inc.'tagdb.php';
-		include_once $tag_inc.'entry.php';
+		$tag_inc = dirname(__FILE__) . '/inc/';
+		include_once $tag_inc . 'tagdb.php';
+		include_once $tag_inc . 'entry.php';
 
-		$this->tagdb_class=new plugin_tag_db();
+		$this->tagdb_class = new plugin_tag_db();
 
-		$this->entry_class=new plugin_tag_entry($this->tagdb_class);
+		$this->entry_class = new plugin_tag_entry($this->tagdb_class);
 
 		# Check for the cache
-		if(!is_dir(PLUGIN_TAG_DIR) && !PLUGIN_TAG_NOCACHE) {
+		if (!is_dir(PLUGIN_TAG_DIR) && !PLUGIN_TAG_NOCACHE) {
 			$this->tagdb_class->makeCache($this->entry_class);
 		}
 
-		## Init only if we're in index
-		if(defined('MOD_INDEX')) {
-			include_once $tag_inc.'init.php';
-			$this->init_class=new plugin_tag_init($this->tagdb_class);
+		# # Init only if we're in index
+		if (defined('MOD_INDEX')) {
+			include_once $tag_inc . 'init.php';
+			$this->init_class = new plugin_tag_init($this->tagdb_class);
 		}
 
 		# The PrettyURLs Hack
-		if(class_exists('Plugin_PrettyURLs')) {
-			include_once $tag_inc.'prettyurls.php';
-			$this->rewrite_link=true;
+		if (class_exists('Plugin_PrettyURLs')) {
+			include_once $tag_inc . 'prettyurls.php';
+			$this->rewrite_link = true;
 		}
 
 		# Rewrite URLs: just for links
-		if(class_exists('plugin_rewriteurls')) {
-			$this->rewrite_link=true;
+		if (class_exists('plugin_rewriteurls')) {
+			$this->rewrite_link = true;
 		}
 
 		# Update tags when you post an entry
-		if(defined('MOD_ADMIN_PANEL')) {
-			include_once $tag_inc.'admin.php';
-			$this->admin_class=new plugin_tag_admin($this->tagdb_class, $this->entry_class);
-			$this->admin_class->use_rewrite=$this->rewrite_link;
+		if (defined('MOD_ADMIN_PANEL')) {
+			include_once $tag_inc . 'admin.php';
+			$this->admin_class = new plugin_tag_admin($this->tagdb_class, $this->entry_class);
+			$this->admin_class->use_rewrite = $this->rewrite_link;
 		}
 
 		# To be compatible with Flatpress style...
-		add_filter('tag_link', array(&$this, 'tag_link'), 1, 1);
+		add_filter('tag_link', array(
+			&$this,
+			'tag_link'
+		), 1, 1);
 
 		# The widgets. They requires FP >= 0.1010
-		register_widget('tag', 'Tag', array(&$this, 'tag_cloud'));
-		register_widget('related', 'Related', array(&$this, 'tag_related'));
-		$smarty->register_function('related_entries', array(&$this, 'smarty_related'));
+		register_widget('tag', 'Tag', array(
+			&$this,
+			'tag_cloud'
+		));
+		register_widget('related', 'Related', array(
+			&$this,
+			'tag_related'
+		));
+		$smarty->registerPlugin('function', 'related_entries', array(
+			&$this,
+			'smarty_related'
+		));
 	}
 
 	# Link to the tags
@@ -105,32 +121,33 @@ class plugin_tag {
 	 * called via hook system to be compatible with Flatpress
 	 * style/system.
 	 *
-	 * @param string $tag: the tag you want the link of
+	 * @param string $tag:
+	 *        	the tag you want the link of
 	 * @returns string: The tag URL
 	 */
 	function tag_link($tag) {
-		if($this->rewrite_link) {
+		if ($this->rewrite_link) {
 
 			# Get the Tag URL Cache
-			$sanitized=$this->tagdb_class->rewriteCache();
+			$sanitized = $this->tagdb_class->rewriteCache();
 
 			# If we don't have the name for rewrite, we return normal link
-			if(FALSE===$k=array_search($tag, $sanitized)) {
-				return BLOG_BASEURL.'?tag='.urlencode($tag);
+			if (FALSE === $k = array_search($tag, $sanitized)) {
+				return BLOG_BASEURL . '?tag=' . urlencode($tag);
 			}
-			$tag=$k.'/';
+			$tag = $k . '/';
 
 			global $plugin_rewriteurls, $plugin_prettyurls;
-			if(class_exists('Plugin_PrettyURLs')) {
-				return $plugin_prettyurls->baseurl.'tag/'.$tag;
+			if (class_exists('Plugin_PrettyURLs')) {
+				return $plugin_prettyurls->baseurl . 'tag/' . $tag;
 			}
-			if(class_exists('plugin_rewriteurls')) {
-				return $plugin_rewriteurls->baseurl.'tag/'.$tag;
+			if (class_exists('plugin_rewriteurls')) {
+				return $plugin_rewriteurls->baseurl . 'tag/' . $tag;
 			}
 		}
 
 		# In every case this link works.
-		return BLOG_BASEURL.'?tag='.urlencode($tag);
+		return BLOG_BASEURL . '?tag=' . urlencode($tag);
 	}
 
 	/**
@@ -141,10 +158,10 @@ class plugin_tag {
 	 * functions...
 	 */
 	function tag_cloud() {
-		if(!isset($this->widget_class)) {
-			$tag_inc=dirname(__FILE__).'/inc/';
-			include_once $tag_inc.'widget.php';
-			$this->widget_class=new plugin_tag_widget($this->tagdb_class, $this->entry_class);
+		if (!isset($this->widget_class)) {
+			$tag_inc = dirname(__FILE__) . '/inc/';
+			include_once $tag_inc . 'widget.php';
+			$this->widget_class = new plugin_tag_widget($this->tagdb_class, $this->entry_class);
 		}
 
 		return $this->widget_class->tagCloud();
@@ -158,10 +175,10 @@ class plugin_tag {
 	 * functions...
 	 */
 	function tag_related() {
-		if(!isset($this->widget_class)) {
-			$tag_inc=dirname(__FILE__).'/inc/';
-			include_once $tag_inc.'widget.php';
-			$this->widget_class=new plugin_tag_widget($this->tagdb_class, $this->entry_class);
+		if (!isset($this->widget_class)) {
+			$tag_inc = dirname(__FILE__) . '/inc/';
+			include_once $tag_inc . 'widget.php';
+			$this->widget_class = new plugin_tag_widget($this->tagdb_class, $this->entry_class);
 		}
 
 		return $this->widget_class->tagRelated();
@@ -171,29 +188,31 @@ class plugin_tag {
 	 * This is the related entries for Smarty.
 	 * I put here since I don't want to include always the widget class.
 	 *
-	 * @param array $params: The parameters for the function
-	 * @param object $smarty: The Smarty Object
+	 * @param array $params:
+	 *        	The parameters for the function
+	 * @param object $smarty:
+	 *        	The Smarty Object
 	 * @return string: The output
 	 */
 	function smarty_related($params, &$smarty) {
-		if(!isset($this->widget_class)) {
-			$tag_inc=dirname(__FILE__).'/inc/';
-			include_once $tag_inc.'widget.php';
-			$this->widget_class=new plugin_tag_widget($this->tagdb_class, $this->entry_class);
+		if (!isset($this->widget_class)) {
+			$tag_inc = dirname(__FILE__) . '/inc/';
+			include_once $tag_inc . 'widget.php';
+			$this->widget_class = new plugin_tag_widget($this->tagdb_class, $this->entry_class);
 		}
 
-		if(!isset($params['id'])) {
-			$params['id']='';
+		if (!isset($params ['id'])) {
+			$params ['id'] = '';
 		}
-		if(!isset($params['number'])) {
-			$params['number']=PLUGIN_TAG_REL;
+		if (!isset($params ['number'])) {
+			$params ['number'] = PLUGIN_TAG_REL;
 		}
 
-		$widget=$this->widget_class->tagRelated($params['id'], $params['number']);
-		return $widget['content'];
+		$widget = $this->widget_class->tagRelated($params ['id'], $params ['number']);
+		return $widget ['content'];
 	}
 
 }
 
 global $plugin_tag;
-$plugin_tag=new plugin_tag;
+$plugin_tag = new plugin_tag();


### PR DESCRIPTION
With the upcoming FlatPress 1.3 updating Smarty to v4, the Smarty function names have changed. I felt free to update the Tag plugin to continue working, and to call the new version "2.6".
Would be great to have this pulled and created an "official" release with.

All the best,
Arvid